### PR TITLE
Removed mutation of momentjs instance, instead moment as injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,91 +1,96 @@
-var moment = require('moment');
-
-moment.fn.preciseDiff = function(d2, opts) {
-  return moment.preciseDiff(this, d2, opts);
-};
-moment.preciseDiff = function(d1, d2, opts) {
-  var m1 = moment(d1), m2 = moment(d2);
-  opts = opts || {
-    year: true,
-    month: true,
-    day: true,
-    hour: true,
-    minute: true,
-    second: true
-  }
-
-  if (m1.isSame(m2)) {
-    return '';
-  }
-  if (m1.isAfter(m2)) {
-    var tmp = m1;
-    m1 = m2;
-    m2 = tmp;
-  }
-
-  var yDiff = m2.year() - m1.year();
-  var mDiff = m2.month() - m1.month();
-  var dDiff = m2.date() - m1.date();
-  var hourDiff = m2.hour() - m1.hour();
-  var minDiff = m2.minute() - m1.minute();
-  var secDiff = m2.second() - m1.second();
-
-  if (secDiff < 0) {
-    secDiff = 60 + secDiff;
-    minDiff--;
-  }
-  if (minDiff < 0) {
-    minDiff = 60 + minDiff;
-    hourDiff--;
-  }
-  if (hourDiff < 0) {
-    hourDiff = 24 + hourDiff;
-    dDiff--;
-  }
-  if (dDiff < 0) {
-    var daysInLastFullMonth = moment(m2.year() + '-' + (m2.month() + 1), "YYYY-MM")
-      .subtract(1, 'months').daysInMonth();
-    if (daysInLastFullMonth < m1.date()) { // 31/01 -> 2/03
-      dDiff = daysInLastFullMonth + dDiff + (m1.date() - daysInLastFullMonth);
-    } else {
-      dDiff = daysInLastFullMonth + dDiff;
+module.exports = function(moment) {
+    if (!moment || !moment.isMoment || (typeof moment.isMoment !== 'function')) {
+        throw new Error('Input argument "moment" is required and must be type of "Momentjs" type.' + 
+            'Use require("moment-precise-range")(moment).');
     }
-    mDiff--;
-  }
-  if (mDiff < 0) {
-    mDiff = 12 + mDiff;
-    yDiff--;
-  }
 
-  var result = [];
+    var defaults = {
+        year: true,
+        month: true,
+        day: true,
+        hour: true,
+        minute: true,
+        second: true,
+        joinSeparator: ' '
+    };
 
-  moment.relativeTimeThreshold('s',60);
-  moment.relativeTimeThreshold('m',60);
-  moment.relativeTimeThreshold('h',23);
-  moment.relativeTimeThreshold('dd',28);
-  moment.relativeTimeThreshold('dm',45);
-  moment.relativeTimeThreshold('dy',365);
+    return function preciseDiff(d1, d2, opts) {
+        var m1 = moment(d1), m2 = moment(d2);
+        opts = opts || defaults;
 
-  if (yDiff && opts.year) {
-    result.push(moment.duration(yDiff,'year').humanize());
-  }
-  if (mDiff && opts.month) {
-    result.push(moment.duration(mDiff,'month').humanize());
-  }
-  if (dDiff && opts.day) {
-    result.push(moment.duration(dDiff,'day').humanize());
-  }
-  if (hourDiff && opts.hour) {
-    result.push(moment.duration(hourDiff,'hour').humanize());
-  }
-  if (minDiff && opts.minute) {
-    result.push(moment.duration(minDiff,'minute').humanize());
-  }
-  if (secDiff && opts.second) {
-    result.push(moment.duration(secDiff,'second').humanize());
-  }
+        if (m1.isSame(m2)) {
+            return '';
+        }
+        if (m1.isAfter(m2)) {
+            var tmp = m1;
+            m1 = m2;
+            m2 = tmp;
+        }
 
-  return result.join(' ');
-};
+        var yDiff = m2.year() - m1.year();
+        var mDiff = m2.month() - m1.month();
+        var dDiff = m2.date() - m1.date();
+        var hourDiff = m2.hour() - m1.hour();
+        var minDiff = m2.minute() - m1.minute();
+        var secDiff = m2.second() - m1.second();
 
-module.exports = moment;
+        if (secDiff < 0) {
+            secDiff = 60 + secDiff;
+            minDiff--;
+        }
+        if (minDiff < 0) {
+            minDiff = 60 + minDiff;
+            hourDiff--;
+        }
+        if (hourDiff < 0) {
+            hourDiff = 24 + hourDiff;
+            dDiff--;
+        }
+        if (dDiff < 0) {
+            var daysInLastFullMonth = moment(m2.year() + '-' + (m2.month() + 1), "YYYY-MM")
+                .subtract(1, 'months').daysInMonth();
+            if (daysInLastFullMonth < m1.date()) { // 31/01 -> 2/03
+                dDiff = daysInLastFullMonth + dDiff + (m1.date() - daysInLastFullMonth);
+            } else {
+                dDiff = daysInLastFullMonth + dDiff;
+            }
+            mDiff--;
+        }
+        if (mDiff < 0) {
+            mDiff = 12 + mDiff;
+            yDiff--;
+        }
+
+        var result = [];
+
+        moment.relativeTimeThreshold('s', 60);
+        moment.relativeTimeThreshold('m', 60);
+        moment.relativeTimeThreshold('h', 23);
+        moment.relativeTimeThreshold('dd', 28);
+        moment.relativeTimeThreshold('dm', 45);
+        moment.relativeTimeThreshold('dy', 365);
+
+        if (yDiff && opts.year) {
+            result.push(moment.duration(yDiff, 'year').humanize());
+        }
+        if (mDiff && opts.month) {
+            result.push(moment.duration(mDiff, 'month').humanize());
+        }
+        if (dDiff && opts.day) {
+            result.push(moment.duration(dDiff, 'day').humanize());
+        }
+        if (hourDiff && opts.hour) {
+            result.push(moment.duration(hourDiff, 'hour').humanize());
+        }
+        if (minDiff && opts.minute) {
+            result.push(moment.duration(minDiff, 'minute').humanize());
+        }
+        if (secDiff && opts.second) {
+            result.push(moment.duration(secDiff, 'second').humanize());
+        }
+        
+        var joinSeparator = opts.joinSeparator || defaults.joinSeparator;
+
+        return result.join(joinSeparator);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -21,10 +21,9 @@
     "url": "https://github.com/mtscout6/moment-precise-range/issues"
   },
   "homepage": "https://github.com/mtscout6/moment-precise-range",
-  "dependencies": {
-    "moment": "^2.8.1"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "moment": "^2.8.1",
     "coveralls": "^2.10.1",
     "istanbul": "^0.3.0",
     "mocha": "^1.21.4",

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,13 @@
 // lang = 'en'
-var moment = require('../');
+var moment = require('moment');
+var preciseDiff = require('../')(moment);
 var assert = require('assert');
 
 describe('preciseDiff', function() {
   function test(d1, d2, result, opts) {
     assert.equal(
-      moment.preciseDiff(moment(d1, 'YYYY-MM-DD HH:mm:ss'),
-                         moment(d2, 'YYYY-MM-DD HH:mm:ss'), opts),
+      preciseDiff(moment(d1, 'YYYY-MM-DD HH:mm:ss'),
+        moment(d2, 'YYYY-MM-DD HH:mm:ss'), opts),
     result);
   }
 


### PR DESCRIPTION
- momentjs is not anymore direct dependency, just dev dep, so now lib must be required like this:
```
var moment = require('moment');
var preciseDiff = require("moment-precise-range")(moment);
```
- new option joinSeparator is introduced
- updated tests to work with those changes 